### PR TITLE
Send params as URL-encoded JSON in the URL fragment by default. Use ifra...

### DIFF
--- a/lib/iframe.js
+++ b/lib/iframe.js
@@ -1,5 +1,3 @@
-var extend = require('util-extend');
-
 var VER = 1;
 var TYPE = 'gardr';
 var REFRESH_KEY = 'refresh-' + TYPE;
@@ -17,11 +15,6 @@ function getOrigin(loc) {
     return loc.origin || (loc.protocol + '//' + loc.hostname + (loc.port ? ':' + loc.port : ''));
 }
 
-function updateNameData (el, id, data) {
-    var nameData = extend({id: id}, data);
-    el.name = JSON.stringify(nameData);
-}
-
 function Iframe(id, options) {
     if (typeof id !== 'string' || !id) {
         throw new Error('Iframe missing id');
@@ -36,7 +29,7 @@ function Iframe(id, options) {
     this.height = options.height || '100px';
     this.classes = options.classes || '';
     this.hidden = options.hidden;
-    this.data = {};
+    this.setData(options.data || {});
 }
 
 Iframe.prototype.remove = function() {
@@ -63,6 +56,7 @@ Iframe.prototype.addFailedClass = function() {
 
 Iframe.prototype.setData = function (data) {
     data.origin = getOrigin(document.location);
+    data.id = this.id;
     this.data = data;
 };
 
@@ -73,17 +67,23 @@ Iframe.prototype._getUrl = function(src) {
     }
     var sep = baseUrl.indexOf('?') !== -1 ? '&' : '?';
     var refresh = src && src.indexOf(REFRESH_KEY) === -1 ? REFRESH_KEY + '=true&' : '';
-    return [
+    var params = JSON.stringify(this.data);
+    var url = [
         baseUrl,
         sep,
         'ver=', VER,
-        '&',
-        refresh
+        '&', refresh,
+        '#', encodeURIComponent(params)
     ].join('');
+    if (url.length >= 2083) {
+        // IE has a limit for URLs longer than 2083 bytes, so fallback to iframe.name if the URL is too long
+        url = url.split('#')[0];
+        this.element.name = params;
+    }
+    return url;
 };
 
 Iframe.prototype.refresh = function () {
-    updateNameData(this.element, this.id, this.data);
     this.element.src = this._getUrl(this.element.src);
 };
 
@@ -108,7 +108,6 @@ Iframe.prototype.makeIframe = function() {
     wrapper.className = (classes.join(' ')).toLowerCase();
     wrapper.setAttribute('data-' + TYPE, this.id);
     i.setAttribute('data-automation-id', this.id);
-    updateNameData(this.element, this.id, this.data);
     i.src = this._getUrl();
     i.className = TYPE + '-iframe';
     // IE 7-8

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -215,10 +215,10 @@ proto.createIframe = function (item) {
             width: item.options.width,
             height: item.options.height,
             hidden: item.options.hidden,
-            classes: ''
+            classes: '',
+            data: this._getItemData(item)
         });
 
-        item.iframe.setData( this._getItemData(item) );
         item.iframe.makeIframe();
     }
 };


### PR DESCRIPTION
...me.name as fallback when URL is too long.

Using iframe.name to pass data works well on the web, but not from apps. They use WebViews instead of iframes, and it's hard or not possible to define the name variable synchronously from the app-code. URLs are easier to debug both for apps and web, but using query-parameters are limiting if we want a “scope” for each plugin to pass parameters to the ext frame. So using a JSON in the URL is the best of both, but IE has a max URL-length of 2083 characters, so on the web we should fallback to using iframe.name if the URL-length is too long.
