### PR TITLE
Extending all attributes from the rendered banner to item in host

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -82,8 +82,12 @@ function Manager(options, pluginHandler) {
     xde.on('rendered', function(msg) {
         var item = this._getById(msg.data.id);
         if (item) {
-            item.rendered.width = msg.data.width;
-            item.rendered.height = msg.data.height;
+			// copy all attributes from banner, 
+			// but maintain times, since its reserved
+			var times = item.rendered.times;
+			extend(item.rendered, msg.data);
+			item.rendered.times = times;
+			
             this._resolve(item);
         }
     }.bind(this));


### PR DESCRIPTION
We need to be able to send more than width and height from the rendered banner, up to Gardr host.
