### PR TITLE
allow for custom element tag

### DIFF
--- a/lib/iframe.js
+++ b/lib/iframe.js
@@ -25,6 +25,7 @@ function Iframe(id, options) {
     }
     this.element = null;
     this.iframeUrl = options.iframeUrl;
+    this.elementTag = options.elementTag || 'iframe';
     this.width = options.width || '100%';
     this.height = options.height || '100px';
     this.classes = options.classes || '';
@@ -88,7 +89,7 @@ Iframe.prototype.refresh = function () {
 };
 
 Iframe.prototype._createIframeElement = function () {
-    return document.createElement('iframe');
+    return document.createElement(this.elementTag);
 };
 
 Iframe.prototype.makeIframe = function() {
@@ -108,8 +109,15 @@ Iframe.prototype.makeIframe = function() {
     wrapper.className = (classes.join(' ')).toLowerCase();
     wrapper.setAttribute('data-' + TYPE, this.id);
     i.setAttribute('data-automation-id', this.id);
-    i.src = this._getUrl();
-    i.className = TYPE + '-iframe';
+
+    if(this.elementTag === 'object') {
+        i.data = this._getUrl();
+    }
+    else {
+        i.src = this._getUrl();
+    }
+
+    i.className = TYPE + '-' + this.elementTag;
     // IE 7-8
     i.marginWidth = 0;
     i.marginHeight = 0;

--- a/lib/manager.js
+++ b/lib/manager.js
@@ -215,6 +215,7 @@ proto.createIframe = function (item) {
             width: item.options.width,
             height: item.options.height,
             hidden: item.options.hidden,
+            elementTag: item.options.elementTag,
             classes: '',
             data: this._getItemData(item)
         });

--- a/test/iframe.test.js
+++ b/test/iframe.test.js
@@ -38,9 +38,31 @@ describe('iframe', function () {
         expect(iframe.id).to.equal(id);
     });
 
+    it('should create <iframe> element by default', function () {
+        var asIframe = new Iframe('as-iframe', {iframeUrl: iframeUrl});
+        asIframe.makeIframe();
+        expect(asIframe.element.tagName.toLowerCase()).to.equal('iframe');
+    });
+
+    it('should create <object> element on demand', function () {
+        var asObject = new Iframe('as-object', {iframeUrl: iframeUrl, elementTag: 'object'});
+        asObject.makeIframe();
+        expect(asObject.element.tagName.toLowerCase()).to.equal('object');
+    });
+    
+    it('should set id as property on the instance', function () {
+        expect(iframe.id).to.equal(id);
+    });
+
     it('should use iframeUrl for iframe src', function () {
         iframe.makeIframe();
         expect(iframe.element.src.indexOf(iframeUrl) === 0).to.equal(true);
+    });
+
+    it('should use iframeUrl for object data', function () {
+        var asObject = new Iframe('as-object', {iframeUrl: iframeUrl, elementTag: 'object'});
+        asObject.makeIframe();
+        expect(asObject.element.data.indexOf(iframeUrl) === 0).to.equal(true);
     });
 
     it('should set a JSON-string including the id as hash on iframe src', function () {


### PR DESCRIPTION
Some versions of iOS have unusual behavior when in comes to resizing iframes. They disallow doing it at all, css width and height is being ignored, and also iframe is as wide as it's content - meaning that if content exceeds iframe size, iframe will be widened.
Easiest way I've found to deal with this problem is to use object tag instead of iframe. It essentially behaves the same, but doesn't have resizing problems.
Hence the pull request, maybe let's use iframes by default but allow user to use objects if needed?
