### PR TITLE
Workaround for iOS Safari bug

### DIFF
--- a/lib/iframe.js
+++ b/lib/iframe.js
@@ -15,6 +15,13 @@ function getOrigin(loc) {
     return loc.origin || (loc.protocol + '//' + loc.hostname + (loc.port ? ':' + loc.port : ''));
 }
 
+function fixIosResponsiveIframeBug (ifr) {
+    if (ifr.width === '100%') {
+        ifr.element.style.width = '1px';
+        ifr.element.style.minWidth = '100%';
+    }
+}
+
 function Iframe(id, options) {
     if (typeof id !== 'string' || !id) {
         throw new Error('Iframe missing id');
@@ -124,6 +131,7 @@ Iframe.prototype.makeIframe = function() {
     //i.height = this.height;
     i.style.width = validSize(this.width);
     i.style.height = validSize(this.height);
+    fixIosResponsiveIframeBug(this);
     i.style.border = '0';
     i.style.display = 'block';
     // stop scroll

--- a/test/iframe.test.js
+++ b/test/iframe.test.js
@@ -59,6 +59,16 @@ describe('iframe', function () {
         expect(iframe.element.style.height).to.equal('200px');
     });
 
+    it('should have a responsive width if no width specified', function () {
+        var iframe = new Iframe('resize-test', {height:200, iframeUrl:'about:blank'});
+        iframe.makeIframe();
+        // Safari on iOS forces the iframe size to equal the visible content size if it has 100% width.
+        // This is a trick to work around that bug. See discussion here:
+        // https://github.com/gardr/host/pull/8
+        expect(iframe.element.style.width).to.equal('1px');
+        expect(iframe.element.style.minWidth).to.equal('100%');
+    });
+
     it('should encode data object to a JSON-string as hash on the iframe src', function () {
         iframe.setData({
             aNumber: 100,


### PR DESCRIPTION
This is a fix for a bug/feature in Safari on iOS that forces the width of an iframe (that has width: 100%) to the same width as the content document of the iframe.

See discussion in #8