### PR TITLE
Issue-16 Add tabindex -1 to iframe

### DIFF
--- a/lib/iframe.js
+++ b/lib/iframe.js
@@ -123,6 +123,8 @@ Iframe.prototype.makeIframe = function() {
     i.name = this.id + '-' + (+new Date());
     i.src = this._getUrl();
     i.className = TYPE + '-iframe';
+    // https://github.com/gardr/host/pull/16
+    i.tabIndex = -1;
     // IE 7-8
     i.marginWidth = 0;
     i.marginHeight = 0;
@@ -139,8 +141,6 @@ Iframe.prototype.makeIframe = function() {
     // stop scroll
     i.style.overflow = 'hidden';
     i.scrolling = 'no';
-
-
 
     inner.appendChild(i);
     inner.className = TYPE + '-inner';

--- a/test/iframe.test.js
+++ b/test/iframe.test.js
@@ -112,4 +112,10 @@ describe('iframe', function () {
         expect(iframe.resize).to.not.throw(Error);
     });
 
+    it('should add tabindex as an iframe attribute', function () {
+        iframe.makeIframe();
+        expect(iframe.element.tabIndex).to.equal(-1);
+    });
+
+
 });


### PR DESCRIPTION
Tested on firefox and chrome (Linux), safari (osx) & ie11 (win10). Banner iframe is ignored by all.