### PR TITLE
Browsers seem to cache iframes when certain cache headers are set.

### DIFF
--- a/lib/iframe.js
+++ b/lib/iframe.js
@@ -118,8 +118,9 @@ Iframe.prototype.makeIframe = function() {
     wrapper.className = (classes.join(' ')).toLowerCase();
     wrapper.setAttribute('data-' + TYPE, this.id);
     i.setAttribute('data-automation-id', this.id);
-    // iframe.name chrome cache issue https://github.com/gardr/host/pull/15
-    i.name = this.id + '-' + (+new Date());
+    // iframe.name and iframe.id chrome/ie/ff cache issue https://github.com/gardr/host/pull/15
+    i.id = i.name = this.id + '-' + (+new Date());
+
     i.title = this.title;
     i.src = this._getUrl();
     i.className = TYPE + '-iframe';


### PR DESCRIPTION
This causes iframes to request the URL from previous page views. Using the name attribute fix on ID as well solves the issue.
